### PR TITLE
gops/net.go: add support for lxc[bridge] network device monitoring

### DIFF
--- a/gops/net.go
+++ b/gops/net.go
@@ -26,7 +26,7 @@ func (self *GopsUtil) GetNetworkInfo() ([]*models.NetworkInfo, error) {
 }
 
 func matchesNetworkInterface(name string) bool {
-	prefixes := []string{"wlan", "eth", "enp", "wlp", "ens", "eno"}
+	prefixes := []string{"wlan", "eth", "enp", "wlp", "ens", "eno", "lxc"}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(name, prefix) {
 			return true


### PR DESCRIPTION
Minimal change to add a new network device pattern.
Really interesting here to use dgop on a system running LXC containers.