### PR TITLE
Makefile: remove sudo calls from install/uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@ build:
 # Install the binary to system path
 install: build
 	@echo "Installing $(BINARY_NAME) to $(INSTALL_DIR)..."
-	@sudo cp $(BUILD_DIR)/$(BINARY_NAME) $(INSTALL_DIR)/$(BINARY_NAME)
-	@sudo chmod +x $(INSTALL_DIR)/$(BINARY_NAME)
+	@cp $(BUILD_DIR)/$(BINARY_NAME) $(INSTALL_DIR)/$(BINARY_NAME)
+	@chmod +x $(INSTALL_DIR)/$(BINARY_NAME)
 	@echo "Installation complete"
 
 # Uninstall the binary from system path
 uninstall:
 	@echo "Uninstalling $(BINARY_NAME) from $(INSTALL_DIR)..."
-	@sudo rm -f $(INSTALL_DIR)/$(BINARY_NAME)
+	@rm -f $(INSTALL_DIR)/$(BINARY_NAME)
 	@echo "Uninstall complete"
 
 # Clean build artifacts


### PR DESCRIPTION
Is there a reason to be using sudo in the Makefile on the install/uninstall targets?

Shouldn't these targets be run as root or by sudo outside the Makefile logic? In the README.md seems to be right explained but the Makefile adds those sudo calls which aren't really needed if "make install" runs as root or with sudo.