### PR TITLE
Add CPU core display options for high-core systems

### DIFF
--- a/cmd/cli/commands.go
+++ b/cmd/cli/commands.go
@@ -743,5 +743,5 @@ func runDiskRateCommand(gopsUtil *gops.GopsUtil) error {
 }
 
 func runTopCommand(gopsUtil *gops.GopsUtil) error {
-	return runTUI(gopsUtil)
+	return runTUIWithOptions(gopsUtil, hideCPUCores, summarizeCores)
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -24,6 +24,8 @@ var (
 	procCursor     string
 	netRateCursor  string
 	diskRateCursor string
+	hideCPUCores   bool
+	summarizeCores bool
 )
 
 var style = lipgloss.NewStyle().
@@ -92,13 +94,16 @@ func init() {
 
 	gpuTempCmd.Flags().StringVar(&gpuPciId, "pci-id", "", "PCI ID of GPU to get temperature (e.g., 10de:2684)")
 	gpuTempCmd.MarkFlagRequired("pci-id")
+
+	topCmd.Flags().BoolVar(&hideCPUCores, "hide-cpu-cores", false, "Hide individual CPU core display in TUI")
+	topCmd.Flags().BoolVar(&summarizeCores, "summarize-cores", false, "Show summarized CPU core groups instead of individual cores")
 }
 
 var rootCmd = &cobra.Command{
 	Use: "dankgop",
 	Run: func(cmd *cobra.Command, args []string) {
 		gopsUtil := gops.NewGopsUtil()
-		runTopCommand(gopsUtil)
+		runTUIWithOptions(gopsUtil, hideCPUCores, summarizeCores)
 	},
 }
 

--- a/cmd/cli/tui/components.go
+++ b/cmd/cli/tui/components.go
@@ -15,6 +15,10 @@ import (
 )
 
 func NewResponsiveTUIModel(gopsUtil *gops.GopsUtil) *ResponsiveTUIModel {
+	return NewResponsiveTUIModelWithOptions(gopsUtil, false, false)
+}
+
+func NewResponsiveTUIModelWithOptions(gopsUtil *gops.GopsUtil, hideCPUCores, summarizeCores bool) *ResponsiveTUIModel {
 	colorManager, err := config.NewColorManager()
 	if err != nil {
 		colorManager = nil
@@ -72,6 +76,8 @@ func NewResponsiveTUIModel(gopsUtil *gops.GopsUtil) *ResponsiveTUIModel {
 		maxDiskHistory: 60,
 		selectedPID:    -1,
 		logoTestMode:   false,
+		hideCPUCores:   hideCPUCores,
+		summarizeCores: summarizeCores,
 	}
 
 	hardware, _ := gopsUtil.GetSystemHardware()

--- a/cmd/cli/tui/model.go
+++ b/cmd/cli/tui/model.go
@@ -78,6 +78,9 @@ type ResponsiveTUIModel struct {
 	logoTestMode     bool
 	currentLogoIndex int
 	lastLogoUpdate   time.Time
+
+	hideCPUCores   bool
+	summarizeCores bool
 }
 
 func (m *ResponsiveTUIModel) Cleanup() {

--- a/cmd/cli/tui/panels.go
+++ b/cmd/cli/tui/panels.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"fmt"
 	"strings"
+
+	"github.com/AvengeMedia/dgop/models"
 )
 
 func (m *ResponsiveTUIModel) renderCPUPanel(width, height int) string {
@@ -31,7 +33,7 @@ func (m *ResponsiveTUIModel) renderCPUPanel(width, height int) string {
 	// CPU name as title, with right-aligned frequency - align with core layout
 	freqText := fmt.Sprintf("%.0fMHz", cpu.Frequency)
 	// Calculate spaces to align with core columns - adjust for proper C/MHz alignment
-	availableWidth := width - 5                                 // account for borders+padding, align with cores
+	availableWidth := width - 5 // account for borders+padding, align with cores
 	spaces := availableWidth - len(cpuName) - len(freqText)
 	if spaces < 1 {
 		spaces = 1
@@ -52,56 +54,24 @@ func (m *ResponsiveTUIModel) renderCPUPanel(width, height int) string {
 	tempText := fmt.Sprintf("%.0f°C", cpu.Temperature)
 	content.WriteString(fmt.Sprintf("%s %s %s\n", cpuBar, usageText, tempText))
 
-	// All cores with bars in 3 columns filling 100% width
-	if len(cpu.CoreUsage) > 0 {
-		// Each column gets 33% of available width (accounting for borders/padding)
-		availableWidth := width - 4 // Account for borders/padding
-		columnWidth := availableWidth / 3
-
-		// Each core needs space for "C00" (3 chars) + bar + "100%" (4 chars) = 7 + bar (no spaces)
-		coreBarWidth := columnWidth - 8 // More space for wider bars
-		if coreBarWidth < 6 {
-			coreBarWidth = 6
+	// Cores display - handle hide/summarize options
+	if len(cpu.CoreUsage) > 0 && !m.hideCPUCores {
+		if m.summarizeCores {
+			// Summarized core display for systems with many cores
+			m.renderSummarizedCores(&content, cpu, width)
+		} else {
+			// Original detailed core display
+			m.renderDetailedCores(&content, cpu, width)
 		}
+	}
 
-		for i := 0; i < len(cpu.CoreUsage); i += 3 {
-			var line strings.Builder
-
-			// First core - format as "C01[bar]5%" with no spaces, add separator
-			core1 := cpu.CoreUsage[i]
-			core1Bar := m.renderProgressBar(uint64(core1*100), 10000, coreBarWidth, "cpu")
-			core1Str := fmt.Sprintf("C%02d%s%3.0f%%", i, core1Bar, core1) // No spaces
-			line.WriteString(core1Str)
-			line.WriteString(" ") // Space separator between columns
-
-			// Second core if exists
-			if i+1 < len(cpu.CoreUsage) {
-				core2 := cpu.CoreUsage[i+1]
-				core2Bar := m.renderProgressBar(uint64(core2*100), 10000, coreBarWidth, "cpu")
-				core2Str := fmt.Sprintf("C%02d%s%3.0f%%", i+1, core2Bar, core2)
-				line.WriteString(core2Str)
-				line.WriteString(" ") // Space separator between columns
-			}
-
-			// Third core if exists
-			if i+2 < len(cpu.CoreUsage) {
-				core3 := cpu.CoreUsage[i+2]
-				core3Bar := m.renderProgressBar(uint64(core3*100), 10000, coreBarWidth, "cpu")
-				core3Str := fmt.Sprintf("C%02d%s%3.0f%%", i+2, core3Bar, core3)
-				line.WriteString(core3Str) // No separator after last column
-			}
-
-			content.WriteString(line.String() + "\n")
-		}
-
-		// Add load/tasks/threads on a single line under CPU cores
-		if m.metrics != nil && m.metrics.System != nil {
-			systemInfo := fmt.Sprintf("Load: %s | Tasks: %d | Threads: %d",
-				m.metrics.System.LoadAvg,
-				m.metrics.System.Processes,
-				m.metrics.System.Threads)
-			content.WriteString(systemInfo)
-		}
+	// Add load/tasks/threads on a single line under CPU cores
+	if m.metrics != nil && m.metrics.System != nil {
+		systemInfo := fmt.Sprintf("Load: %s | Tasks: %d | Threads: %d",
+			m.metrics.System.LoadAvg,
+			m.metrics.System.Processes,
+			m.metrics.System.Threads)
+		content.WriteString(systemInfo)
 	}
 
 	// Ensure content fills allocated height
@@ -118,4 +88,107 @@ func (m *ResponsiveTUIModel) renderCPUPanel(width, height int) string {
 	return style.Render(strings.Join(lines, "\n"))
 }
 
+func (m *ResponsiveTUIModel) renderDetailedCores(content *strings.Builder, cpu *models.CPUInfo, width int) {
+	// Original detailed core display (3 columns)
+	availableWidth := width - 4 // Account for borders/padding
+	columnWidth := availableWidth / 3
 
+	// Each core needs space for "C00" (3 chars) + bar + "100%" (4 chars) = 7 + bar (no spaces)
+	coreBarWidth := columnWidth - 8 // More space for wider bars
+	if coreBarWidth < 6 {
+		coreBarWidth = 6
+	}
+
+	for i := 0; i < len(cpu.CoreUsage); i += 3 {
+		var line strings.Builder
+
+		// First core - format as "C01[bar]5%" with no spaces, add separator
+		core1 := cpu.CoreUsage[i]
+		core1Bar := m.renderProgressBar(uint64(core1*100), 10000, coreBarWidth, "cpu")
+		core1Str := fmt.Sprintf("C%02d%s%3.0f%%", i, core1Bar, core1) // No spaces
+		line.WriteString(core1Str)
+		line.WriteString(" ") // Space separator between columns
+
+		// Second core if exists
+		if i+1 < len(cpu.CoreUsage) {
+			core2 := cpu.CoreUsage[i+1]
+			core2Bar := m.renderProgressBar(uint64(core2*100), 10000, coreBarWidth, "cpu")
+			core2Str := fmt.Sprintf("C%02d%s%3.0f%%", i+1, core2Bar, core2)
+			line.WriteString(core2Str)
+			line.WriteString(" ") // Space separator between columns
+		}
+
+		// Third core if exists
+		if i+2 < len(cpu.CoreUsage) {
+			core3 := cpu.CoreUsage[i+2]
+			core3Bar := m.renderProgressBar(uint64(core3*100), 10000, coreBarWidth, "cpu")
+			core3Str := fmt.Sprintf("C%02d%s%3.0f%%", i+2, core3Bar, core3)
+			line.WriteString(core3Str) // No separator after last column
+		}
+
+		content.WriteString(line.String() + "\n")
+	}
+}
+
+func (m *ResponsiveTUIModel) renderSummarizedCores(content *strings.Builder, cpu *models.CPUInfo, width int) {
+	// Summarized core display for high-core systems
+	totalCores := len(cpu.CoreUsage)
+
+	// Group cores into batches (e.g., 8 or 16 cores per group)
+	groupSize := 8
+	if totalCores > 64 {
+		groupSize = 16 // Larger groups for very high core count systems
+	}
+
+	availableWidth := width - 4
+	barWidth := availableWidth - 25 // Leave space for text
+	if barWidth < 10 {
+		barWidth = 10
+	}
+
+	for i := 0; i < totalCores; i += groupSize {
+		endIdx := i + groupSize
+		if endIdx > totalCores {
+			endIdx = totalCores
+		}
+
+		// Calculate average usage for this group
+		var avgUsage float64
+		var maxUsage float64
+		activeCount := 0
+
+		for j := i; j < endIdx; j++ {
+			usage := cpu.CoreUsage[j]
+			avgUsage += usage
+			if usage > maxUsage {
+				maxUsage = usage
+			}
+			if usage > 1.0 {
+				activeCount++
+			}
+		}
+		avgUsage /= float64(endIdx - i)
+
+		// Display group summary
+		groupName := fmt.Sprintf("C%02d-%02d", i, endIdx-1)
+		avgBar := m.renderProgressBar(uint64(avgUsage*100), 10000, barWidth, "cpu")
+		groupInfo := fmt.Sprintf("%s %s %3.0f%% avg (max:%3.0f%% active:%d)\n",
+			groupName, avgBar, avgUsage, maxUsage, activeCount)
+		content.WriteString(groupInfo)
+	}
+
+	// Add a summary line
+	var totalActive int
+	var totalAvg float64
+	for _, usage := range cpu.CoreUsage {
+		totalAvg += usage
+		if usage > 1.0 {
+			totalActive++
+		}
+	}
+	totalAvg /= float64(totalCores)
+
+	summary := fmt.Sprintf("Total: %d cores, %d active (>1%%), %.1f%% average\n",
+		totalCores, totalActive, totalAvg)
+	content.WriteString(summary)
+}

--- a/cmd/cli/tui_runner.go
+++ b/cmd/cli/tui_runner.go
@@ -7,8 +7,12 @@ import (
 )
 
 func runTUI(gopsUtil *gops.GopsUtil) error {
+	return runTUIWithOptions(gopsUtil, false, false)
+}
+
+func runTUIWithOptions(gopsUtil *gops.GopsUtil, hideCPUCores, summarizeCores bool) error {
 	tui.Version = Version
-	model := tui.NewResponsiveTUIModel(gopsUtil)
+	model := tui.NewResponsiveTUIModelWithOptions(gopsUtil, hideCPUCores, summarizeCores)
 	defer model.Cleanup()
 
 	p := tea.NewProgram(


### PR DESCRIPTION
- Add --hide-cpu-cores flag to completely hide individual CPU core display in TUI
- Add --summarize-cores flag to show grouped CPU core statistics instead of individual cores
- Improve usability on systems with many cores (64+, 256+ cores) where individual core display overwhelms the interface
- Summarize mode groups cores into batches (8-16 cores per group) showing average, max usage, and active count
- Both flags work with the 'top' command to provide better process visibility on high-core systems
- Maintains backward compatibility with existing behavior when no flags are specified