### PR TITLE
Add ACPI thermal zone support for CPU and GPU temperature detection

### DIFF
--- a/gops/hardware.go
+++ b/gops/hardware.go
@@ -505,51 +505,76 @@ func getHwmonTemperature(pciId string) (float64, string) {
 		}
 	}
 
-	// Fallback to ACPI thermal zones for integrated GPUs (like AMD Radeon 8060S on HP Zbook Ultra G1A)
-	// Some integrated GPUs don't expose hwmon sensors but may have thermal info in ACPI
 	thermalPath := "/sys/class/thermal"
 	thermalEntries, err := os.ReadDir(thermalPath)
-	if err == nil {
-		var maxTemp float64
-		var foundTemp bool
+	if err != nil {
+		return 0, "unknown"
+	}
 
-		for _, entry := range thermalEntries {
-			if !strings.HasPrefix(entry.Name(), "thermal_zone") {
-				continue
-			}
-
-			typePath := filepath.Join(thermalPath, entry.Name(), "type")
-			typeBytes, err := os.ReadFile(typePath)
-			if err != nil {
-				continue
-			}
-
-			thermalType := strings.TrimSpace(string(typeBytes))
-			// Look for ACPI thermal zones that might represent GPU temperature
-			if thermalType == "acpitz" {
-				tempPath := filepath.Join(thermalPath, entry.Name(), "temp")
-				tempBytes, err := os.ReadFile(tempPath)
-				if err == nil {
-					temp, err := strconv.Atoi(strings.TrimSpace(string(tempBytes)))
-					if err == nil {
-						tempC := float64(temp) / 1000.0
-						// Consider temperatures in typical GPU range (20-90°C)
-						// Use the second-highest temp as it's often GPU on APU systems
-						if tempC >= 20 && tempC <= 90 && tempC > maxTemp {
-							maxTemp = tempC
-							foundTemp = true
-						}
-					}
-				}
-			}
-		}
-
-		if foundTemp {
-			return maxTemp, "acpitz"
-		}
+	maxTemp := getMaxACPITZTemperatureForGPU(thermalPath, thermalEntries, 20, 90)
+	if maxTemp > 0 {
+		return maxTemp, "acpitz"
 	}
 
 	return 0, "unknown"
+}
+
+func getMaxACPITZTemperatureForGPU(thermalPath string, thermalEntries []os.DirEntry, minTemp, maxTemp float64) float64 {
+	var highestTemp float64
+
+	for _, entry := range thermalEntries {
+		if !strings.HasPrefix(entry.Name(), "thermal_zone") {
+			continue
+		}
+
+		thermalType, err := readThermalTypeForGPU(thermalPath, entry.Name())
+		if err != nil {
+			continue
+		}
+
+		if thermalType != "acpitz" {
+			continue
+		}
+
+		temp, err := readThermalTempForGPU(thermalPath, entry.Name())
+		if err != nil {
+			continue
+		}
+
+		if temp < minTemp || temp > maxTemp {
+			continue
+		}
+
+		if temp > highestTemp {
+			highestTemp = temp
+		}
+	}
+
+	return highestTemp
+}
+
+func readThermalTypeForGPU(thermalPath, entryName string) (string, error) {
+	typePath := filepath.Join(thermalPath, entryName, "type")
+	typeBytes, err := os.ReadFile(typePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(typeBytes)), nil
+}
+
+func readThermalTempForGPU(thermalPath, entryName string) (float64, error) {
+	tempPath := filepath.Join(thermalPath, entryName, "temp")
+	tempBytes, err := os.ReadFile(tempPath)
+	if err != nil {
+		return 0, err
+	}
+
+	temp, err := strconv.Atoi(strings.TrimSpace(string(tempBytes)))
+	if err != nil {
+		return 0, err
+	}
+
+	return float64(temp) / 1000.0, nil
 }
 
 func readFile(path string) (string, error) {


### PR DESCRIPTION
This patch adds fallback support for ACPI thermal zones when traditional hwmon sensors are not available. This enables temperature monitoring on devices like the HP Zbook Ultra G1A with AMD Ryzen AI MAX+ PRO 395 and integrated Radeon 8060S Graphics.

Changes:
- CPU: Added ACPI thermal zone fallback in getCPUTemperatureCached()
  - Reads from /sys/class/thermal/thermal_zone*/temp
  - Returns the highest reasonable temperature (20-100°C) from acpitz zones
  - Caches the path for faster subsequent reads

- GPU: Added ACPI thermal zone fallback in getHwmonTemperature()
  - Falls back to acpitz thermal zones for integrated GPUs
  - Returns the highest temperature in typical GPU range (20-90°C)
  - Reports hwmon type as 'acpitz' for transparency

Testing:
- Tested on HP Zbook Ultra G1A (AMD Ryzen AI MAX+ PRO 395)
- CPU temperature: Successfully detected via ACPI thermal zones
- GPU temperature: Successfully detected via ACPI thermal zones
- Maintains backward compatibility with existing hwmon-based detection

This enhancement improves hardware compatibility, particularly for:
- Newer AMD APU systems with integrated graphics
- Laptops that rely on ACPI thermal management
- Systems where kernel drivers don't expose hwmon sensors