### PR TITLE
flake: rename cli to dgop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
 
             installPhase = ''
               mkdir -p $out/bin
-              cp $GOPATH/bin/cli $out/bin/dgop
+              cp $GOPATH/bin/dgop $out/bin/dgop
               wrapProgram $out/bin/dgop --prefix PATH : "${lib.makeBinPath [ pkgs.pciutils ]}"
 
               installShellCompletion --cmd dgop \


### PR DESCRIPTION
fixes nix build for e76b8aa90f2dc1e3c36ec36d4a0ed06f4b4fdce6