### PR TITLE
gops: measure process CPU over the sampling interval

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,10 +66,6 @@ linters:
       - linters:
           - errcheck
         text: "Error return value of `(w\\.Write|huma\\.WriteErr|recovererErrorWriter\\.Write)` is not checked"
-      # Process CPU priming call (intentionally ignored)
-      - linters:
-          - errcheck
-        text: "Error return value of `p\\.CPUPercent` is not checked"
       # Cleanup operations
       - linters:
           - errcheck

--- a/gops/processes.go
+++ b/gops/processes.go
@@ -1,17 +1,120 @@
 package gops
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math"
 	"reflect"
 	"runtime"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/AvengeMedia/dgop/models"
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/process"
 )
+
+const (
+	cpuBaselineInterval   = 200 * time.Millisecond
+	maxCursorDecodedBytes = 4 << 20
+)
+
+// A fresh gzip writer allocates ~850KB of flate hash tables, which is wasteful
+// for the ~4KB cursor emitted on every poll. Reuse them instead.
+var cursorWriters = sync.Pool{
+	New: func() any {
+		gz, _ := gzip.NewWriterLevel(io.Discard, gzip.BestCompression)
+		return gz
+	},
+}
+
+type processCursorWire struct {
+	BaseMillis   int64   `json:"t"`
+	PIDs         []int32 `json:"pid"`
+	CPUMillis    []int64 `json:"cpu"`
+	OffsetMillis []int64 `json:"dt"`
+}
+
+func encodeProcessCursor(entries []models.ProcessCursorData) string {
+	wire := processCursorWire{
+		PIDs:         make([]int32, 0, len(entries)),
+		CPUMillis:    make([]int64, 0, len(entries)),
+		OffsetMillis: make([]int64, 0, len(entries)),
+	}
+	for i, e := range entries {
+		if i == 0 || e.Timestamp < wire.BaseMillis {
+			wire.BaseMillis = e.Timestamp
+		}
+	}
+	for _, e := range entries {
+		wire.PIDs = append(wire.PIDs, e.PID)
+		wire.CPUMillis = append(wire.CPUMillis, int64(math.Round(e.Ticks*1000)))
+		wire.OffsetMillis = append(wire.OffsetMillis, e.Timestamp-wire.BaseMillis)
+	}
+
+	raw, _ := json.Marshal(wire)
+	var buf bytes.Buffer
+	gz := cursorWriters.Get().(*gzip.Writer)
+	defer cursorWriters.Put(gz)
+	gz.Reset(&buf)
+	_, _ = gz.Write(raw)
+	_ = gz.Close()
+	return base64.RawURLEncoding.EncodeToString(buf.Bytes())
+}
+
+func decodeProcessCursor(cursor string) map[int32]*models.ProcessCursorData {
+	out := make(map[int32]*models.ProcessCursorData)
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil || len(raw) == 0 {
+		return out
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return out
+	}
+	defer func() { _ = gz.Close() }()
+	if raw, err = io.ReadAll(io.LimitReader(gz, maxCursorDecodedBytes)); err != nil {
+		return out
+	}
+
+	var wire processCursorWire
+	if json.Unmarshal(raw, &wire) != nil {
+		return out
+	}
+	if len(wire.CPUMillis) != len(wire.PIDs) || len(wire.OffsetMillis) != len(wire.PIDs) {
+		return out
+	}
+	entries := make([]models.ProcessCursorData, len(wire.PIDs))
+	for i, pid := range wire.PIDs {
+		entries[i] = models.ProcessCursorData{
+			PID:       pid,
+			Ticks:     float64(wire.CPUMillis[i]) / 1000,
+			Timestamp: wire.BaseMillis + wire.OffsetMillis[i],
+		}
+		out[pid] = &entries[i]
+	}
+	return out
+}
+
+// gopsutil can panic on macOS when reading process info for system processes
+// or processes that exit mid-read, and this runs on the request goroutine
+// where a panic would take down the whole call.
+func readProcessTimes(p *process.Process) (times *cpu.TimesStat) {
+	defer func() {
+		if recover() != nil {
+			times = nil
+		}
+	}()
+	times, _ = p.Times()
+	return times
+}
 
 func (self *GopsUtil) GetProcesses(sortBy ProcSortBy, limit int, enableCPU bool, mergeChildren bool) (*models.ProcessListResponse, error) {
 	return self.GetProcessesWithCursor(sortBy, limit, enableCPU, "", mergeChildren)
@@ -24,36 +127,32 @@ func (self *GopsUtil) GetProcessesWithCursor(sortBy ProcSortBy, limit int, enabl
 	}
 
 	totalMem, _ := self.memProvider.VirtualMemory()
-	currentTime := time.Now().UnixMilli()
 
-	cursorMap := make(map[int32]*models.ProcessCursorData)
-	if cursor != "" {
-		jsonBytes, err := base64.RawURLEncoding.DecodeString(cursor)
-		if err == nil {
-			var cursors []models.ProcessCursorData
-			if json.Unmarshal(jsonBytes, &cursors) == nil {
-				for i := range cursors {
-					cursorMap[cursors[i].PID] = &cursors[i]
-				}
-			}
-		}
-	}
+	cursorMap := decodeProcessCursor(cursor)
 
 	if enableCPU && len(cursorMap) == 0 {
-		maxSample := 100
-		if len(procs) < maxSample {
-			maxSample = len(procs)
+		for _, p := range procs {
+			times := readProcessTimes(p)
+			if times == nil {
+				continue
+			}
+			cursorMap[p.Pid] = &models.ProcessCursorData{
+				PID:       p.Pid,
+				Ticks:     times.User + times.System,
+				Timestamp: time.Now().UnixMilli(),
+			}
 		}
-		for i := 0; i < maxSample; i++ {
-			_, _ = procs[i].CPUPercent()
-		}
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(cpuBaselineInterval)
 	}
 
 	type procResult struct {
-		index int
-		info  *models.ProcessInfo
+		index     int
+		info      *models.ProcessInfo
+		sampledAt int64
+		sampled   bool
 	}
+
+	numCPU := float64(runtime.NumCPU())
 
 	numWorkers := runtime.NumCPU()
 	if numWorkers > 8 {
@@ -88,6 +187,7 @@ func (self *GopsUtil) GetProcessesWithCursor(sortBy ProcSortBy, limit int, enabl
 					ppid, _ := p.Ppid()
 					memInfo, _ := p.MemoryInfo()
 					times, _ := p.Times()
+					sampledAt := time.Now().UnixMilli()
 					username, _ := p.Username()
 					exePath, _ := p.Exe()
 
@@ -98,8 +198,13 @@ func (self *GopsUtil) GetProcessesWithCursor(sortBy ProcSortBy, limit int, enabl
 
 					cpuPercent := 0.0
 					if enableCPU {
-						rawCpuPercent, _ := p.CPUPercent()
-						cpuPercent = rawCpuPercent / float64(runtime.NumCPU())
+						if cursorData, hasCursor := cursorMap[p.Pid]; hasCursor {
+							coreRate := calculateProcessCPUPercentageWithCursor(cursorData, currentCPUTime, sampledAt)
+							cpuPercent = coreRate / numCPU
+							if cpuPercent > 100 {
+								cpuPercent = 100
+							}
+						}
 					}
 
 					rssKB := uint64(0)
@@ -128,7 +233,9 @@ func (self *GopsUtil) GetProcessesWithCursor(sortBy ProcSortBy, limit int, enabl
 					}
 
 					results <- procResult{
-						index: idx,
+						index:     idx,
+						sampledAt: sampledAt,
+						sampled:   true,
 						info: &models.ProcessInfo{
 							PID:               p.Pid,
 							PPID:              ppid,
@@ -158,9 +265,17 @@ func (self *GopsUtil) GetProcessesWithCursor(sortBy ProcSortBy, limit int, enabl
 	close(jobs)
 
 	procList := make([]*models.ProcessInfo, len(procs))
+	cursorList := make([]models.ProcessCursorData, 0, len(procs))
 	for i := 0; i < len(procs); i++ {
 		r := <-results
 		procList[r.index] = r.info
+		if r.sampled {
+			cursorList = append(cursorList, models.ProcessCursorData{
+				PID:       r.info.PID,
+				Ticks:     r.info.PTicks,
+				Timestamp: r.sampledAt,
+			})
+		}
 	}
 
 	if mergeChildren {
@@ -194,21 +309,9 @@ func (self *GopsUtil) GetProcessesWithCursor(sortBy ProcSortBy, limit int, enabl
 		procList = procList[:limit]
 	}
 
-	cursorList := make([]models.ProcessCursorData, 0, len(procList))
-	for _, proc := range procList {
-		cursorList = append(cursorList, models.ProcessCursorData{
-			PID:       proc.PID,
-			Ticks:     proc.PTicks,
-			Timestamp: currentTime,
-		})
-	}
-
-	cursorBytes, _ := json.Marshal(cursorList)
-	cursorStr := base64.RawURLEncoding.EncodeToString(cursorBytes)
-
 	return &models.ProcessListResponse{
 		Processes: procList,
-		Cursor:    cursorStr,
+		Cursor:    encodeProcessCursor(cursorList),
 	}, nil
 }
 
@@ -243,23 +346,13 @@ func calculateProcessCPUPercentageWithCursor(cursor *models.ProcessCursorData, c
 		return 0
 	}
 
-	cpuTimeDiff := currentCPUTime - cursor.Ticks
 	wallTimeDiff := float64(currentTime-cursor.Timestamp) / 1000.0
-
 	if wallTimeDiff <= 0 {
 		return 0
 	}
 
-	cpuPercent := (cpuTimeDiff / wallTimeDiff) * 100.0
-
-	if cpuPercent > 100.0 {
-		cpuPercent = 100.0
-	}
-	if cpuPercent < 0 {
-		cpuPercent = 0
-	}
-
-	return cpuPercent
+	cpuTimeDiff := currentCPUTime - cursor.Ticks
+	return (cpuTimeDiff / wallTimeDiff) * 100.0
 }
 
 func findMergeRoot(p *models.ProcessInfo, pidMap map[int32]*models.ProcessInfo) *models.ProcessInfo {

--- a/gops/processes.go
+++ b/gops/processes.go
@@ -235,7 +235,7 @@ func (self *GopsUtil) GetProcessesWithCursor(sortBy ProcSortBy, limit int, enabl
 					results <- procResult{
 						index:     idx,
 						sampledAt: sampledAt,
-						sampled:   true,
+						sampled:   times != nil,
 						info: &models.ProcessInfo{
 							PID:               p.Pid,
 							PPID:              ppid,

--- a/gops/processes_cursor_integration_test.go
+++ b/gops/processes_cursor_integration_test.go
@@ -1,0 +1,121 @@
+package gops
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/AvengeMedia/dgop/gops/mocks"
+	"github.com/AvengeMedia/dgop/models"
+	"github.com/shirou/gopsutil/v4/mem"
+	"github.com/shirou/gopsutil/v4/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newProcessTestUtil(t *testing.T, procs ...*process.Process) *GopsUtil {
+	t.Helper()
+
+	mockProc := mocks.NewMockProcessInfoProvider(t)
+	mockProc.EXPECT().Processes().Return(procs, nil).Once()
+
+	mockMem := mocks.NewMockMemoryInfoProvider(t)
+	mockMem.EXPECT().VirtualMemory().Return(&mem.VirtualMemoryStat{Total: 16 << 30}, nil).Once()
+
+	return NewGopsUtilWithProviders(
+		mocks.NewMockCPUInfoProvider(t),
+		mockMem,
+		mocks.NewMockDiskInfoProvider(t),
+		mocks.NewMockNetworkInfoProvider(t),
+		mockProc,
+		mocks.NewMockHostInfoProvider(t),
+		mocks.NewMockLoadInfoProvider(t),
+		mocks.NewMockFileSystem(t),
+	)
+}
+
+func TestGetProcessesWithCursor_UsesCursorForCPU(t *testing.T) {
+	self, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+
+	times, err := self.Times()
+	require.NoError(t, err)
+
+	cursor := encodeProcessCursor([]models.ProcessCursorData{{
+		PID:       self.Pid,
+		Ticks:     times.User + times.System - 5.0,
+		Timestamp: time.Now().UnixMilli() - 10_000,
+	}})
+
+	util := newProcessTestUtil(t, self)
+
+	res, err := util.GetProcessesWithCursor(SortByCPU, 0, true, cursor, false)
+	require.NoError(t, err)
+	require.Len(t, res.Processes, 1)
+
+	// 5 CPU-seconds over a 10s interval is half a core, reported as a share of the whole machine.
+	expected := 50.0 / float64(runtime.NumCPU())
+	assert.InDelta(t, expected, res.Processes[0].CPU, expected/10,
+		"CPU must be the rate over the cursor interval, not an average over the process lifetime")
+}
+
+func TestGetProcessesWithCursor_ClampsToWholeMachine(t *testing.T) {
+	self, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+
+	times, err := self.Times()
+	require.NoError(t, err)
+
+	// An implausible amount of CPU over a very short interval, as a stale or
+	// hand-crafted cursor would produce.
+	cursor := encodeProcessCursor([]models.ProcessCursorData{{
+		PID:       self.Pid,
+		Ticks:     times.User + times.System - 1000.0,
+		Timestamp: time.Now().UnixMilli() - 10,
+	}})
+
+	util := newProcessTestUtil(t, self)
+
+	res, err := util.GetProcessesWithCursor(SortByCPU, 0, true, cursor, false)
+	require.NoError(t, err)
+	require.Len(t, res.Processes, 1)
+
+	assert.Equal(t, 100.0, res.Processes[0].CPU,
+		"CPU is a share of the whole machine and must never be published above 100")
+}
+
+func TestGetProcessesWithCursor_CursorCoversAllProcesses(t *testing.T) {
+	self, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+	parent, err := process.NewProcess(int32(os.Getppid()))
+	require.NoError(t, err)
+
+	util := newProcessTestUtil(t, self, parent)
+
+	res, err := util.GetProcessesWithCursor(SortByCPU, 1, false, "", true)
+	require.NoError(t, err)
+	require.Len(t, res.Processes, 1)
+
+	assert.Len(t, decodeProcessCursor(res.Cursor), 2,
+		"cursor must cover every process, not only the merged and limited page, or excluded processes report 0 forever")
+}
+
+func TestGetProcessesWithCursor_TimestampsTrackEachRead(t *testing.T) {
+	self, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+
+	before := time.Now().UnixMilli()
+	util := newProcessTestUtil(t, self)
+
+	res, err := util.GetProcessesWithCursor(SortByCPU, 0, true, "", false)
+	require.NoError(t, err)
+	after := time.Now().UnixMilli()
+
+	entry, ok := decodeProcessCursor(res.Cursor)[self.Pid]
+	require.True(t, ok)
+
+	assert.GreaterOrEqual(t, entry.Timestamp, before+cpuBaselineInterval.Milliseconds(),
+		"cursor timestamp must be when times were sampled, not when the request started")
+	assert.LessOrEqual(t, entry.Timestamp, after)
+}

--- a/gops/processes_cursor_integration_test.go
+++ b/gops/processes_cursor_integration_test.go
@@ -85,6 +85,16 @@ func TestGetProcessesWithCursor_ClampsToWholeMachine(t *testing.T) {
 		"CPU is a share of the whole machine and must never be published above 100")
 }
 
+func TestGetProcessesWithCursor_SkipsCursorEntryWhenTimesUnreadable(t *testing.T) {
+	util := newProcessTestUtil(t, &process.Process{Pid: 999999})
+
+	res, err := util.GetProcessesWithCursor(SortByCPU, 0, true, "", false)
+	require.NoError(t, err)
+
+	assert.Empty(t, decodeProcessCursor(res.Cursor),
+		"a process whose CPU times could not be read must not enter the cursor as 0 ticks")
+}
+
 func TestGetProcessesWithCursor_CursorCoversAllProcesses(t *testing.T) {
 	self, err := process.NewProcess(int32(os.Getpid()))
 	require.NoError(t, err)

--- a/gops/processes_test.go
+++ b/gops/processes_test.go
@@ -1,11 +1,15 @@
 package gops
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"testing"
 	"time"
 
 	"github.com/AvengeMedia/dgop/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateProcessCPUPercentageWithCursor(t *testing.T) {
@@ -72,6 +76,19 @@ func TestCalculateProcessCPUPercentageWithCursor(t *testing.T) {
 			currentCPUTime: 10.25,
 			currentTime:    baseTime + 1000,
 			expected:       25.0,
+		},
+		{
+			// This helper reports the raw single-core rate; GetProcessesWithCursor
+			// divides by core count and clamps before the value is published.
+			name: "four cores of work in one second is four cores of single-core rate",
+			cursor: &models.ProcessCursorData{
+				PID:       1234,
+				Ticks:     0.0,
+				Timestamp: baseTime,
+			},
+			currentCPUTime: 4.0,
+			currentTime:    baseTime + 1000,
+			expected:       400.0,
 		},
 		{
 			name: "zero timestamp",
@@ -197,6 +214,95 @@ func TestCalculateProcessCPUPercentageRealWorld(t *testing.T) {
 func TestGetPssDirty(t *testing.T) {
 	_, err := getPssDirty(999999)
 	assert.Error(t, err, "Should error for non-existent PID")
+}
+
+func TestProcessCursorRoundTrip(t *testing.T) {
+	base := int64(1_755_000_000_000)
+	entries := []models.ProcessCursorData{
+		{PID: 1, Ticks: 12.34, Timestamp: base},
+		{PID: 4242, Ticks: 98765.43, Timestamp: base + 57},
+		{PID: 999999, Ticks: 0, Timestamp: base - 12},
+	}
+
+	decoded := decodeProcessCursor(encodeProcessCursor(entries))
+
+	require.Len(t, decoded, 3)
+	for _, want := range entries {
+		got, ok := decoded[want.PID]
+		require.True(t, ok, "pid %d missing", want.PID)
+		assert.Equal(t, want.Timestamp, got.Timestamp, "per-process timestamps must survive")
+		assert.Equal(t, want.Ticks, got.Ticks)
+	}
+}
+
+func TestProcessCursorFitsInAQueryParam(t *testing.T) {
+	entries := make([]models.ProcessCursorData, 0, 500)
+	for i := range 500 {
+		entries = append(entries, models.ProcessCursorData{
+			PID: int32(i * 7), Ticks: float64(i) * 13.37, Timestamp: 1_755_000_000_000 + int64(i%200),
+		})
+	}
+
+	encoded := encodeProcessCursor(entries)
+
+	assert.Less(t, len(encoded), 6000)
+	assert.Len(t, decodeProcessCursor(encoded), 500)
+}
+
+func gzipB64(t *testing.T, payload string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(payload))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	return base64.RawURLEncoding.EncodeToString(buf.Bytes())
+}
+
+func TestProcessCursorRejectsBadInput(t *testing.T) {
+	for name, cursor := range map[string]string{
+		"empty":            "",
+		"not base64":       "!!!not base64!!!",
+		"not gzip":         base64.RawURLEncoding.EncodeToString([]byte(`[{"pid":1}]`)),
+		"truncated gzip":   base64.RawURLEncoding.EncodeToString([]byte{0x1f, 0x8b, 0x08, 0x00}),
+		"short cpu array":  gzipB64(t, `{"t":1,"pid":[1,2,3],"cpu":[1],"dt":[0,0,0]}`),
+		"short dt array":   gzipB64(t, `{"t":1,"pid":[1,2,3],"cpu":[1,2,3],"dt":[]}`),
+		"no arrays at all": gzipB64(t, `{"t":1}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Empty(t, decodeProcessCursor(cursor))
+		})
+	}
+}
+
+func TestProcessCursorEncodesConcurrently(t *testing.T) {
+	entries := make([]models.ProcessCursorData, 0, 300)
+	for i := range 300 {
+		entries = append(entries, models.ProcessCursorData{
+			PID: int32(i), Ticks: float64(i), Timestamp: 1_755_000_000_000 + int64(i),
+		})
+	}
+
+	encoded := make(chan string, 16)
+	for range 16 {
+		go func() { encoded <- encodeProcessCursor(entries) }()
+	}
+
+	for range 16 {
+		assert.Len(t, decodeProcessCursor(<-encoded), 300,
+			"encoders share a pooled gzip writer and must not interleave output")
+	}
+}
+
+func TestProcessCursorCapsDecompression(t *testing.T) {
+	n := maxCursorDecodedBytes / 10
+	bomb := make([]models.ProcessCursorData, 0, n)
+	for i := range n {
+		bomb = append(bomb, models.ProcessCursorData{PID: int32(i), Ticks: 1, Timestamp: 1})
+	}
+
+	assert.Empty(t, decodeProcessCursor(encodeProcessCursor(bomb)),
+		"a cursor that inflates past the cap must be discarded, not decoded")
 }
 
 func BenchmarkCalculateProcessCPUPercentage(b *testing.B) {

--- a/models/process.go
+++ b/models/process.go
@@ -3,8 +3,8 @@ package models
 type ProcessInfo struct {
 	PID               int32   `json:"pid"`
 	PPID              int32   `json:"ppid"`
-	CPU               float64 `json:"cpu"`
-	PTicks            float64 `json:"pticks"`
+	CPU               float64 `json:"cpu" doc:"Percentage of total machine CPU capacity used since the cursor, in the range 0-100."`
+	PTicks            float64 `json:"pticks" doc:"Cumulative CPU seconds (user + system) consumed by this process."`
 	MemoryPercent     float32 `json:"memoryPercent"`
 	MemoryKB          uint64  `json:"memoryKB"`
 	MemoryCalculation string  `json:"memoryCalculation"`
@@ -23,10 +23,6 @@ type ProcessCursorData struct {
 	PID       int32   `json:"pid"`
 	Ticks     float64 `json:"ticks"`
 	Timestamp int64   `json:"timestamp"`
-	Name      string  `json:"name,omitempty"`
-	Cmdline   string  `json:"cmdline,omitempty"`
-	Username  string  `json:"username,omitempty"`
-	PPID      int32   `json:"ppid,omitempty"`
 }
 
 type ProcessListResponse struct {


### PR DESCRIPTION
- restores the cursor branch dropped in 7993019, and moves the 0–100 clamp out
  of the helper into the caller, after dividing by core count
- builds the cursor from all PIDs instead of the returned page. Merged and
  limited-out processes had no entry, so they computed 0 forever.
- per-process cursor timestamps, taken next to each Times() read
- CPUPercent priming loop becomes a Times() snapshot, so the cursor-less path
  measures an interval
- gzipped struct-of-arrays cursor; covering all PIDs is ~5x the entries. Old
  cursors fail to decode and fall back to the baseline path.
- drops unused Name/Cmdline/Username/PPID from ProcessCursorData

Process CPU is still published as a 0–100 share of all cores